### PR TITLE
Add Tailscale Docker Compose role

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -10,6 +10,8 @@
   roles:
     - docker
     - nfs
+    - role: tailscale
+      tailscale_auth_key: "{{ secrets.tailscale_auth_key }}"
   tasks:
     - name: Debug Tailscale Auth Key
       ansible.builtin.debug:

--- a/roles/tailscale/defaults/main.yml
+++ b/roles/tailscale/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+tailscale_image: "tailscale/tailscale:latest"
+tailscale_container_name: "tailscale"
+tailscale_compose_dir: "/opt/docker/tailscale"
+tailscale_volume_name: "tailscale-data"
+tailscale_auth_key: ""
+tailscale_start_compose: true

--- a/roles/tailscale/tasks/main.yml
+++ b/roles/tailscale/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Ensure tailscale compose directory exists
+  ansible.builtin.file:
+    path: "{{ tailscale_compose_dir }}"
+    state: directory
+    owner: root
+    group: docker
+    mode: '0755'
+
+- name: Write tailscale env file
+  ansible.builtin.copy:
+    dest: "{{ tailscale_compose_dir }}/.env"
+    content: |
+      TAILSCALE_AUTHKEY={{ tailscale_auth_key }}
+    owner: root
+    group: docker
+    mode: '0600'
+
+- name: Deploy docker-compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ tailscale_compose_dir }}/docker-compose.yml"
+    owner: root
+    group: docker
+    mode: '0644'
+
+- name: Start tailscale container with docker compose
+  ansible.builtin.command:
+    cmd: docker compose up -d
+    chdir: "{{ tailscale_compose_dir }}"
+  when: tailscale_start_compose

--- a/roles/tailscale/templates/docker-compose.yml.j2
+++ b/roles/tailscale/templates/docker-compose.yml.j2
@@ -1,0 +1,18 @@
+version: '3.8'
+services:
+  tailscale:
+    image: {{ tailscale_image }}
+    container_name: {{ tailscale_container_name }}
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    volumes:
+      - {{ tailscale_volume_name }}:/var/lib
+      - /dev/net/tun:/dev/net/tun
+    env_file:
+      - .env
+    command: tailscaled
+    restart: unless-stopped
+volumes:
+  {{ tailscale_volume_name }}:


### PR DESCRIPTION
## Summary
- add a role to run Tailscale in Docker using docker-compose
- create a compose file template and environment file
- wire up the new role in the main playbook

## Testing
- `ansible-playbook --syntax-check playbook.yml`
- `ansible-playbook --list-tasks playbook.yml`


------
https://chatgpt.com/codex/tasks/task_e_686501e253a48330a4e6475da0c3763b